### PR TITLE
fixed addressing mishap

### DIFF
--- a/Chapter 24/24 move_strings/move_strings.asm
+++ b/Chapter 24/24 move_strings/move_strings.asm
@@ -85,9 +85,9 @@ str_loop3:	mov byte[rdi], al		; the simple method
 		mov rdi,other_string
 		mov rcx, length
     		rep stosb			
-		lea rsi,[my_string+length-4]
-		lea rdi,[other_string+length]
-		mov rcx, 27			;copy only ten characters
+		lea rsi,[my_string+length-5]
+		lea rdi,[other_string+length-1]
+		mov rcx, 26			;copy only ten characters
 		std					;std sets DF, cld clears DF
 		rep movsb
 		prnt other_string,length


### PR DESCRIPTION
I think I found a mistake (**I am still not sure though. If I am wrong, please tell me!**) in the [move_strings.asm](https://github.com/Apress/beginning-x64-assembly-programming/blob/master/Chapter%2024/24%20move_strings/move_strings.asm) file (line 88-92):
```nasm
lea rsi,[my_string+length-4]
lea rdi,[other_string+length]
mov rcx, 27			;copy only ten characters
std					;std sets DF, cld clears DF
rep movsb
```
The author explains that it is necessary to move the value `27` (instead of `26` = number of letters in the alphabet) into the `rcx` register, since the instruction `rep movsb` decreases the `rcx` register before doing anything else in the loop. However, the operation section in the [intel manual](https://software.intel.com/content/www/us/en/develop/download/intel-64-and-ia-32-architectures-sdm-combined-volumes-1-2a-2b-2c-2d-3a-3b-3c-3d-and-4.html) (page 1741) says that first the string operation is performed and **then** the `rcx` register is decreased. In addition to that, the `rsi` and `rdi` registers are loaded with the following instructions:
```nasm
lea rsi, [my_string+length-4]
lea rdi, [other_string+length]
```
This way, the `rdi` register actually points to the byte behind `other_string` and `rsi` points to `{` instead of `z`. This means that in the in first iteration of `rep movsb` the character `{` is copied to the byte behind `rdi` which can also be observed when debugging with gdb (output after the first iteration of `rep movsb`):
```gdb
(gdb) x/96c &other_string
0x40412b <other_string>:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404133:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40413b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404143:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40414b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404153:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40415b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404163:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40416b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404173:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40417b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404183:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	123 '{'
```
In order to prove my findings I changed these lines accordingly:
```nasm
lea rsi,[my_string+length-5]
lea rdi,[other_string+length-1]
mov rcx, 26
std
rep movsb
```
And as expected, the program produced the exact same output as before and when checking with gdb one can see that nothing was copied to the memory location behind `other_string` (output after the first iteration `rep movsb`):
```gdb
(gdb) x/96c &other_string
0x40412b <other_string>:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404133:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40413b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404143:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40414b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404153:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40415b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404163:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40416b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404173:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x40417b:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'
0x404183:	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	48 '0'	122 'z'	0 '\000'
```
I really wanted to share this, since it took me almost 3 hours to find out what was really going on here and I want to spare others the trouble.

By the way, **this book is still absolutely awesome**. It's highly recommendable. Small mistakes like that can always happen.